### PR TITLE
Cleanup NPM cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:alpine
 MAINTAINER @ohbarye <over.rye@gmail.com>
 
-RUN npm install -g swagger-merger watch
+RUN npm install -g swagger-merger watch && npm cache clean --force
 
 CMD ["swagger-merger"]
 


### PR DESCRIPTION
According to https://adambrodziak.pl/dockerfile-good-practices-for-node-and-npm it is a good practice to clean NPM cache after installing packages. This can shave a few bytes off the final image size.

According to my testing:
```
$ docker build --tag swagger-merger:as-is https://github.com/ohbarye/swagger-merger-docker.git
[+] Building 17.6s (5/5) FINISHED                                                                                                                                                                   docker:default
 => [internal] load git source https://github.com/ohbarye/swagger-merger-docker.git                                                                                                                           2.1s
 => [internal] load metadata for docker.io/library/node:alpine                                                                                                                                                1.8s
 => [1/2] FROM docker.io/library/node:alpine@sha256:d3271e4bd89eec4d97087060fd4db0c238d9d22fcfad090a73fa9b5128699888                                                                                         10.1s 
 => => resolve docker.io/library/node:alpine@sha256:d3271e4bd89eec4d97087060fd4db0c238d9d22fcfad090a73fa9b5128699888                                                                                          0.0s 
 => => sha256:f5d3a6aea1b1d35066e6c034f5c264cd5b051fc7c7cb0160bb88899e7b1f0c83 1.16kB / 1.16kB                                                                                                                0.0s 
 => => sha256:6af33fd59f0638fb0acc2992b2b54c7baf68fe593083f0f52815cf29d1288803 7.13kB / 7.13kB                                                                                                                0.0s 
 => => sha256:4abcf20661432fb2d719aaf90656f55c287f8ca915dc1c92ec14ff61e67fbaf8 3.41MB / 3.41MB                                                                                                                1.5s 
 => => sha256:803074618b54a85228c5e10d79b5320e5eba82a2f89abddf233e852420430ba2 2.37MB / 2.37MB                                                                                                                0.7s
 => => sha256:d3271e4bd89eec4d97087060fd4db0c238d9d22fcfad090a73fa9b5128699888 1.43kB / 1.43kB                                                                                                                0.0s
 => => sha256:2997c41553473c7c926a796f330b4a7b03e9d2a7a9ee059a66bf68e02040bf40 43.53MB / 43.53MB                                                                                                              6.8s
 => => sha256:249f9271d1d17cdc2d12d106e2dcfafdc306da21f65123a06aa2290baa5c4fac 451B / 451B                                                                                                                    1.0s
 => => extracting sha256:4abcf20661432fb2d719aaf90656f55c287f8ca915dc1c92ec14ff61e67fbaf8                                                                                                                     0.1s
 => => extracting sha256:2997c41553473c7c926a796f330b4a7b03e9d2a7a9ee059a66bf68e02040bf40                                                                                                                     2.6s
 => => extracting sha256:803074618b54a85228c5e10d79b5320e5eba82a2f89abddf233e852420430ba2                                                                                                                     0.1s
 => => extracting sha256:249f9271d1d17cdc2d12d106e2dcfafdc306da21f65123a06aa2290baa5c4fac                                                                                                                     0.0s
 => [2/2] RUN npm install -g swagger-merger watch                                                                                                                                                             3.3s
 => exporting to image                                                                                                                                                                                        0.1s 
 => => exporting layers                                                                                                                                                                                       0.1s 
 => => writing image sha256:59065a899bb0da3649b8045defa700daf173ef9cbcdd80bda23070cb27d69222                                                                                                                  0.0s 
 => => naming to docker.io/library/swagger-merger:as-is                                                                                                                                                       0.0s 
```
```
$ docker build --tag swagger-merger:with-cleanup https://github.com/i-ky/swagger-merger-docker.git#npm-cache-cleanup
[+] Building 5.1s (5/5) FINISHED                                                                                                                                                                    docker:default 
 => [internal] load git source https://github.com/i-ky/swagger-merger-docker.git#npm-cache-cleanup                                                                                                            1.2s
 => [internal] load metadata for docker.io/library/node:alpine                                                                                                                                                0.5s
 => CACHED [1/2] FROM docker.io/library/node:alpine@sha256:d3271e4bd89eec4d97087060fd4db0c238d9d22fcfad090a73fa9b5128699888                                                                                   0.0s 
 => [2/2] RUN npm install -g swagger-merger watch && npm cache clean --force                                                                                                                                  3.1s 
 => exporting to image                                                                                                                                                                                        0.1s 
 => => exporting layers                                                                                                                                                                                       0.1s 
 => => writing image sha256:e90079181e19c80c96a82a81a5d56f60ad1d11ea04b894fa86496ec97d4b192b                                                                                                                  0.0s 
 => => naming to docker.io/library/swagger-merger:with-cleanup                                                                                                                                                0.0s
```
``` 
$ docker images -f reference=swagger-merger
REPOSITORY       TAG            IMAGE ID       CREATED         SIZE
swagger-merger   with-cleanup   e90079181e19   3 minutes ago   143MB
swagger-merger   as-is          59065a899bb0   7 minutes ago   146MB
```
...the difference (146 MB - 143 MB = 3 MB) is not as impressive, but considering that base image size constitutes most of the image size:
```
$ docker images -f reference=node
REPOSITORY   TAG       IMAGE ID       CREATED       SIZE
node         alpine    6af33fd59f06   2 weeks ago   141MB
```
...and that base image can be shared between multiple images in local cache, there is a noticeable difference in size 146 MB - 141 MB = **5 MB** vs. 143 MB - 141 MB = **2 MB**.